### PR TITLE
fix: component entity id

### DIFF
--- a/Runtime/Base/BaseComponent.cs
+++ b/Runtime/Base/BaseComponent.cs
@@ -26,6 +26,7 @@ namespace andywiecko.ECS
         protected virtual void Awake()
         {
             Entity = GetComponent<Entity>();
+            Entity.TryRegister();
             ComponentId = World.ComponentsRegistry.Counter.GetNext();
         }
         protected virtual void OnEnable() => World.ComponentsRegistry.Add(this);

--- a/Runtime/Base/Entity.cs
+++ b/Runtime/Base/Entity.cs
@@ -15,6 +15,11 @@ namespace andywiecko.ECS
 
         private readonly List<IDisposable> refsToDisposeOnDestroy = new();
 
+        public void TryRegister()
+        {
+            EntityId = EntityId == Id<IEntity>.Invalid ? World.EntitiesCounter.GetNext() : EntityId;
+        }
+
         protected void DisposeOnDestroy(params IDisposable[] references)
         {
             foreach (var reference in references)
@@ -23,10 +28,7 @@ namespace andywiecko.ECS
             }
         }
 
-        protected virtual void Awake()
-        {
-            EntityId = World.EntitiesCounter.GetNext();
-        }
+        protected virtual void Awake() => TryRegister();
 
         protected virtual void OnDestroy()
         {

--- a/Tests/Editor/Base/EntityComponentEditorTests.cs
+++ b/Tests/Editor/Base/EntityComponentEditorTests.cs
@@ -1,3 +1,4 @@
+using andywiecko.BurstCollections;
 using andywiecko.ECS.Tests;
 using NUnit.Framework;
 using System.Linq;
@@ -108,6 +109,14 @@ namespace andywiecko.ECS.Editor.Tests
             // since attributes can be considered as static objects.
             var category = new CategoryAttribute("qwe");
             Assert.That(category.Name, Is.EqualTo("qwe"));
+        }
+
+        [Test]
+        public void ComponentEntityIdTest()
+        {
+            component1.InvokeUnityCallback().Awake();
+
+            Assert.That(component1.EntityId, Is.Not.EqualTo(Id<IEntity>.Invalid));
         }
     }
 }


### PR DESCRIPTION
Due to Unity execution order, `BaseComponent.Awake()` may be called before `Entity.Awake()`, as a consequence during adding component to registry, `EntityId` may not be initialized yet.
It can lead to error regarding auto tuple creation.